### PR TITLE
switching from sp to sf based spatial projections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     rnoaa,
     ncdf4,
     fields,
-	Rcpp
+	Rcpp,
+	sf(>= 0.9-7)
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE) 
 Suggests: knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,8 @@ Imports:
     rnoaa,
     ncdf4,
     fields,
-	Rcpp,
-	sf(>= 0.9-7)
+    Rcpp,
+    sf(>= 0.9-7)
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE) 
 Suggests: knitr,

--- a/R/solartools.R
+++ b/R/solartools.R
@@ -59,15 +59,14 @@ is_raster <- function(r) {
 #' @examples
 #' latlongfromraster(dtm1m)
 #' latlongfromraster(dtm100m)
-latlongfromraster <- function(r) {
+latlongfromraster <- function (r) {
   e <- extent(r)
-  xy <- data.frame(x = (e@xmin + e@xmax) / 2,
-                   y = (e@ymin + e@ymax) / 2)
-  coordinates(xy) = ~x+y
-  proj4string(xy) = crs(r)
-  ll <- as.data.frame(spTransform(xy, CRS("+init=epsg:4326")))
-  ll <- data.frame(lat = ll$y, long = ll$x)
-  ll
+  xy <- data.frame(x = (e@xmin + e@xmax)/2, y = (e@ymin + e@ymax)/2)
+  xy <- sf::st_as_sf(xy, coords = c('x', 'y'), crs = sf::st_crs(r)$wkt)
+  ll <- sf::st_transform(xy, 4326)
+  ll <- data.frame(lat = sf::st_coordinates(ll)[2], 
+                   long = sf::st_coordinates(ll)[1])
+  return(ll)
 }
 #' Calculates the astronomical Julian day
 #'


### PR DESCRIPTION
In order to get `runauto` to work with up-to-date spatial libraries, all references to proj4strings used within the runauto function and it's sub-functions have been rewritten to utilise the sf pacakge. The sf packages can also provide crs info for rasters, and this has been done when appropriate. 

I'd appreciate if you could give it a whirl and a test before merging please Ilya. Feel free to download and install from my fork. 