### PR TITLE
checking 1st class index of objects to avoid multi-condition errors

### DIFF
--- a/R/datatools.R
+++ b/R/datatools.R
@@ -335,7 +335,7 @@ hourlyNCEP <- function(ncepdata = NA, lat, long, tme, reanalysis2 = FALSE) {
   tme <- .tme.sort(tme)
   tmeout <- tme
   tme <- c(tme, tme[length(tme)] + 24 * 3600)
-  if (class(ncepdata) != "logical") {
+  if (class(ncepdata)[1] != "logical") {
     tme <- as.POSIXlt(ncepdata$obs_time)
     tme <- tme[5:(length(tme) - 4)]
   }
@@ -343,7 +343,7 @@ hourlyNCEP <- function(ncepdata = NA, lat, long, tme, reanalysis2 = FALSE) {
   int <- as.numeric(tme[2]) - as.numeric(tme[1])
   lgth <- (length(tme) * int) / (24 * 3600)
   tme2 <- as.POSIXlt(c(0:(lgth - 1)) * 3600 * 24, origin = min(tme), tz = 'UTC')
-  if (class(ncepdata) == "logical") {
+  if (class(ncepdata)[1] == "logical") {
     ncepdata <- get_NCEP(lat, long, tme2, reanalysis2)
   }
   tme6 <- as.POSIXlt(ncepdata$obs_time)
@@ -1101,7 +1101,7 @@ microclimaforNMR <- function(lat, long, dstart, dfinish, l, x, coastal = TRUE, h
     dem <- get_dem(r = NA, lat = lat, long = long, resolution = resolution, zmin = zmin)
   }
   if (class(demmeso)[1] == "logical") demmeso <- dem
-  if (class(hourlydata) == "logical") {
+  if (class(hourlydata)[1] == "logical") {
     cat("Extracting climate data from NCEP \n")
     hourlydata <- hourlyNCEP(ncepdata = NA, lat, long, tme, reanalysis2)
   }
@@ -1318,7 +1318,7 @@ runauto <- function(r, dstart, dfinish, hgt = 0.05, l, x, habitat = NA,
       la <-  habfun(habitat, lat, long, sel = NA, hoy, yr, la, hgt)
       la <- array(la, dim = dim(r)[1:2])
     }
-    if (class(l) == "numeric" | class(l) == "integer") {
+    if (class(l)[1] == "numeric" | class(l)[1] == "integer") {
       if (length(l) == 1) {
         la <- array(l, dim = dim(r)[1:2])
       } else la <- array(l[i], dim = dim(r)[1:2])

--- a/R/runauto2.R
+++ b/R/runauto2.R
@@ -85,19 +85,19 @@
                            res = 1, merid = NA, dst = 0, shadow = TRUE,
                            x, l, difani = TRUE) {
   r <- dtm
-  if (class(slope) == "logical" & class(r) == "RasterLayer") {
+  if (class(slope)[1] == "logical" & class(r)[1] == "RasterLayer") {
     slope <- terrain(r, opt = "slope", unit = "degrees")
     aspect <- terrain(r, opt = "aspect", unit = "degrees")
   }
-  if (class(slope) == "logical" & class(r) != "RasterLayer") {
+  if (class(slope)[1] == "logical" & class(r)[1] != "RasterLayer") {
     slope <- 0
     aspect <- 0
   }
-  if (class(lat) == "logical" & class(crs(r)) == "CRS") {
+  if (class(lat)[1] == "logical" & class(crs(r)) == "CRS") {
     lat <- latlongfromraster(r)$lat
     long <- latlongfromraster(r)$long
   }
-  if (class(lat) == "logical" & class(crs(r)) != "CRS")
+  if (class(lat)[1] == "logical" & class(crs(r)) != "CRS")
     stop("Latitude not defined and cannot be determined from raster")
   if (class(merid) == "logical") merid <- round(long / 15, 0) * 15
   slope <- is_raster(slope)
@@ -336,7 +336,7 @@
 #'      xlab = "Day", ylab = "Temperature")
 runauto2 <- function(dem, hourlydata = NA, dstart, dfinish, lat = NA, long = NA, hgt = 0.05,
                      l, x, veghgt, alb, wind.agg = 10, merid = 0, dst = 0, plot.progress = TRUE) {
-  if (class(hourlydata) == "logical") {
+  if (class(hourlydata)[1] == "logical") {
     tme <- seq(as.POSIXlt(dstart, format = "%d/%m/%Y", origin = "01/01/1900", tz = "UTC"),
                as.POSIXlt(dfinish, format = "%d/%m/%Y", origin = "01/01/1900", tz = "UTC")
                + 3600 * 24, by = 'hours')
@@ -426,8 +426,8 @@ runauto2 <- function(dem, hourlydata = NA, dstart, dfinish, lat = NA, long = NA,
   wc2 <- .rastertoarray(wc2, length(tme))
   a <- .rastertoarray(a, length(tme))
   # Skyviews
-  if (class(lat) == "logical") lat <- latlongfromraster(r)$lat
-  if (class(long) == "logical") long <- latlongfromraster(r)$long
+  if (class(lat)[1] == "logical") lat <- latlongfromraster(r)$lat
+  if (class(long)[1] == "logical") long <- latlongfromraster(r)$long
   tme<-as.POSIXlt(hourlydata$obs_time)
   reso<- res(r)[1]
   svv <- skyviewveg(dem, l2, x2, steps = 36, res = reso)


### PR DESCRIPTION
Following the procedure that's already been implemented in many places in the package, I added a few more instances in which only the first element (index [1]) of an object's class is checked-- this helps avoid an error when the object has multiple classes.

E.g. the following:
```
  if (class(hourlydata) == "logical") {
```

Is now:
```
  if (class(hourlydata)[1] == "logical") {
```

See [this issue](https://github.com/dklinges9/mcera5/issues/18) for context on one example (and I've also encountered this error in some of my own work). I didn't change every class-check throughout the package, but focused on ones that would realistically have multiple classes, and replicating such checks for certain objects that already existed in the package 